### PR TITLE
Add HTTP service tests

### DIFF
--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -1,16 +1,44 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
   let service: AuthService;
+  let http: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(AuthService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+    localStorage.clear();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should send login request', () => {
+    service.login('user', 'pass').subscribe();
+
+    const req = http.expectOne('http://localhost:8080/api/auth/login');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ username: 'user', password: 'pass' });
+    req.flush({ token: 'abc' });
+  });
+
+  it('should send register request', () => {
+    service.register('new', 'secret').subscribe();
+
+    const req = http.expectOne('http://localhost:8080/api/auth/register');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ username: 'new', password: 'secret' });
+    req.flush({});
   });
 });

--- a/src/app/services/event.service.spec.ts
+++ b/src/app/services/event.service.spec.ts
@@ -1,16 +1,56 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { EventService } from './event.service';
 
 describe('EventService', () => {
   let service: EventService;
+  let http: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(EventService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should request active events', () => {
+    service.getActiveEvents().subscribe();
+    const req = http.expectOne('http://localhost:8080/api/events/active');
+    expect(req.request.method).toBe('GET');
+    req.flush([]);
+  });
+
+  it('should request all events', () => {
+    service.getAllEvents().subscribe();
+    const req = http.expectOne('http://localhost:8080/api/events');
+    expect(req.request.method).toBe('GET');
+    req.flush([]);
+  });
+
+  it('should post new event', () => {
+    const ev = { name: 'test' };
+    service.createEvent(ev).subscribe();
+    const req = http.expectOne('http://localhost:8080/api/events');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(ev);
+    req.flush(ev);
+  });
+
+  it('should toggle active state', () => {
+    service.setActive(1, true).subscribe();
+    const req = http.expectOne('http://localhost:8080/api/events/1/activate');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ active: true });
+    req.flush({});
   });
 });

--- a/src/app/services/payment.service.spec.ts
+++ b/src/app/services/payment.service.spec.ts
@@ -1,16 +1,76 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { PaymentService } from './payment.service';
 
 describe('PaymentService', () => {
   let service: PaymentService;
+  let http: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(PaymentService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should register a payment', () => {
+    const file = new File(['x'], 'r.png');
+    service.registerPayment(1, 'GAS', 5, file).subscribe();
+
+    const req = http.expectOne('http://localhost:8080/api/payments');
+    expect(req.request.method).toBe('POST');
+    const body = req.request.body as FormData;
+    expect(body.get('eventId')).toBe('1');
+    expect(body.get('paymentType')).toBe('GAS');
+    expect(body.get('amount')).toBe('5');
+    expect(body.get('receipt')).toBe(file);
+    req.flush({});
+  });
+
+  it('should get my payments', () => {
+    service.getMyPayments(2).subscribe();
+    const req = http.expectOne('http://localhost:8080/api/payments/user/2');
+    expect(req.request.method).toBe('GET');
+    req.flush([]);
+  });
+
+  it('should get receipt image', () => {
+    service.getReceiptImage(3).subscribe();
+    const req = http.expectOne('http://localhost:8080/api/payments/3/receipt');
+    expect(req.request.method).toBe('GET');
+    expect(req.request.responseType).toBe('blob');
+    req.flush(new Blob());
+  });
+
+  it('should get payments for event', () => {
+    service.getPaymentsForEvent(4).subscribe();
+    const req = http.expectOne('http://localhost:8080/api/payments/event/4');
+    expect(req.request.method).toBe('GET');
+    req.flush([]);
+  });
+
+  it('should approve a payment', () => {
+    service.approvePayment(5).subscribe();
+    const req = http.expectOne('http://localhost:8080/api/payments/5/approve');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({});
+    req.flush({});
+  });
+
+  it('should get summary for event', () => {
+    service.getSummaryForEvent(6).subscribe();
+    const req = http.expectOne('http://localhost:8080/api/payments/summary/6');
+    expect(req.request.method).toBe('GET');
+    req.flush({});
   });
 });

--- a/src/app/services/shop-item.service.spec.ts
+++ b/src/app/services/shop-item.service.spec.ts
@@ -1,16 +1,48 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { ShopItemService } from './shop-item.service';
 
 describe('ShopItemService', () => {
   let service: ShopItemService;
+  let http: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(ShopItemService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should request all items', () => {
+    service.getAll().subscribe();
+    const req = http.expectOne('http://localhost:8080/api/items');
+    expect(req.request.method).toBe('GET');
+    req.flush([]);
+  });
+
+  it('should post a new item', () => {
+    const item = { name: 'a' };
+    service.create(item).subscribe();
+    const req = http.expectOne('http://localhost:8080/api/items');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(item);
+    req.flush(item);
+  });
+
+  it('should delete an item', () => {
+    service.delete(1).subscribe();
+    const req = http.expectOne('http://localhost:8080/api/items/1');
+    expect(req.request.method).toBe('DELETE');
+    req.flush({});
   });
 });


### PR DESCRIPTION
## Summary
- expand specs for AuthService and EventService
- test PaymentService HTTP methods
- test ShopItemService API calls

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npx tsc -p tsconfig.spec.json --noEmit` *(fails: cannot find type definition file for 'jasmine')*

------
https://chatgpt.com/codex/tasks/task_e_68449ecaa9a0832ba7e0248a4f69c436